### PR TITLE
Move commentary from PS page 150 to 152

### DIFF
--- a/homestuckCommentary.js
+++ b/homestuckCommentary.js
@@ -7,7 +7,7 @@ module.exports = {
   description: "Adds Andrew Hussie's author commentary from the Problem Sleuth and Homestuck (1-6) books, as well as some additional notes by fans. Credits to Bambosh for the original OCR, Makin for proof of concept and original Homestuck Companion browser extension, Drew Linky for book page to webcomic page conversion, and GiovanH for modding API implementation. More information and Github repo available at https://homestuck.net/collection.html. This mod is open source and licensed under the GPLv3.",
 
   author: "/r/homestuck",
-  version: 0.1,
+  version: 0.2,
 
   footnotes: true,
 
@@ -9346,7 +9346,7 @@ story_author = {
       "content": "Often there will be several long paragraphs following a very simple command. Sometimes it takes a lot of words to explain exactly why a perfectly reasonable solution won't work."
     }
   ],
-  "000368": [
+  "000370": [
     {
       "content": "I'm not sure what happened to the keys... Gun turning into keys = game feature. Keys disappearing because I forgot to paste them in = game glitch."
     }

--- a/src/commentary.json
+++ b/src/commentary.json
@@ -27052,7 +27052,7 @@
     "id": "150",
     "title": "AD: Pick up tommy gun.",
     "page": null,
-    "commentary": "I'm not sure what happened to the keys... Gun turning into keys = game feature. Keys disappearing because I forgot to paste them in = game glitch.",
+    "commentary": null,
     "notes": null
 },
 {
@@ -27066,7 +27066,7 @@
     "id": "152",
     "title": "AD: Slip PS his phone parts.",
     "page": null,
-    "commentary": null,
+    "commentary": "I'm not sure what happened to the keys... Gun turning into keys = game feature. Keys disappearing because I forgot to paste them in = game glitch.",
     "notes": null
 },
 {

--- a/src/footnotes.js
+++ b/src/footnotes.js
@@ -9290,7 +9290,7 @@ story_archivist = {
       "content": "Often there will be several long paragraphs following a very simple command. Sometimes it takes a lot of words to explain exactly why a perfectly reasonable solution won't work."
     }
   ],
-  "000368": [
+  "000370": [
     {
       "content": "I'm not sure what happened to the keys... Gun turning into keys = game feature. Keys disappearing because I forgot to paste them in = game glitch."
     }

--- a/src/footnotes.json
+++ b/src/footnotes.json
@@ -9142,7 +9142,7 @@
           "content": "Often there will be several long paragraphs following a very simple command. Sometimes it takes a lot of words to explain exactly why a perfectly reasonable solution won't work."
         }
       ],
-      "000368": [
+      "000370": [
         {
           "content": "I'm not sure what happened to the keys... Gun turning into keys = game feature. Keys disappearing because I forgot to paste them in = game glitch."
         }


### PR DESCRIPTION
The keys don't actually disappear until page 152, the comment doesn't make sense on page 150.

Running `make.py` gave me syntax errors with both python 2 and 3 so I just made the changes manually based on gefühl in each of the files.